### PR TITLE
Jazzy support

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   trossen_arm_description:
     type: git
     url: https://github.com/TrossenRobotics/trossen_arm_description.git
-    version: main
+    version: jazzy
   trossen_arm:
     type: git
     url: https://github.com/TrossenRobotics/trossen_arm.git

--- a/trossen_arm_bringup/config/controllers.yaml
+++ b/trossen_arm_bringup/config/controllers.yaml
@@ -5,7 +5,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_controller/GripperActionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/trossen_arm_bringup/config/controllers.yaml
+++ b/trossen_arm_bringup/config/controllers.yaml
@@ -5,7 +5,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     gripper_controller:
-      type: parallel_gripper_controller/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/trossen_arm_bringup/package.xml
+++ b/trossen_arm_bringup/package.xml
@@ -13,11 +13,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>controller_manager</depend>
-  <depend>gripper_controllers</depend>
   <depend>joint_state_broadcaster</depend>
   <depend>joint_trajectory_controller</depend>
   <depend>launch_ros</depend>
   <depend>launch</depend>
+  <depend>parallel_gripper_controller</depend>
   <depend>trossen_arm_description</depend>
   <depend>trossen_arm_hardware</depend>
   <depend>xacro</depend>

--- a/trossen_arm_moveit/config/joint_limits.yaml
+++ b/trossen_arm_moveit/config/joint_limits.yaml
@@ -11,30 +11,30 @@ joint_limits:
   joint_0:
     has_velocity_limits: true
     max_velocity: 6.28318531
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 3.141596
   joint_1:
     has_velocity_limits: true
     max_velocity: 6.28318531
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 3.141596
   joint_2:
     has_velocity_limits: true
     max_velocity: 6.28318531
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 3.141596
   joint_3:
     has_velocity_limits: true
     max_velocity: 9.42477796
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 3.141596
   joint_4:
     has_velocity_limits: true
     max_velocity: 9.42477796
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 3.141596
   joint_5:
     has_velocity_limits: true
     max_velocity: 9.42477796
-    has_acceleration_limits: false
-    max_acceleration: 0
+    has_acceleration_limits: true
+    max_acceleration: 3.141596

--- a/trossen_arm_moveit/config/kinematics.yaml
+++ b/trossen_arm_moveit/config/kinematics.yaml
@@ -1,4 +1,4 @@
 arm:
-  kinematics_solver: lma_kinematics_plugin/LMAKinematicsPlugin
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005

--- a/trossen_arm_moveit/config/ompl_planning.yaml
+++ b/trossen_arm_moveit/config/ompl_planning.yaml
@@ -1,12 +1,14 @@
 planning_plugins:
   - ompl_interface/OMPLPlanner
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/ResolveConstraintFrames
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 planner_configs:
   SBL:
     type: geometric::SBL

--- a/trossen_arm_moveit/config/ros2_controllers.yaml
+++ b/trossen_arm_moveit/config/ros2_controllers.yaml
@@ -5,7 +5,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_controller/GripperActionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/trossen_arm_moveit/config/ros2_controllers.yaml
+++ b/trossen_arm_moveit/config/ros2_controllers.yaml
@@ -5,7 +5,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     gripper_controller:
-      type: parallel_gripper_controller/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/trossen_arm_moveit/package.xml
+++ b/trossen_arm_moveit/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>moveit_configs_utils</exec_depend>
@@ -26,6 +25,7 @@
   <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>parallel_gripper_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
@@ -33,7 +33,6 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>trossen_arm_description</exec_depend>
   <exec_depend>trossen_arm_hardware</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>


### PR DESCRIPTION
This PR does the following:
* Removes the unavailable (and also unused) warehouse_ros_mongo package from the moveit package dependencies
* Renames jazzy-deprecated gripper_controllers to parallel_gripper_controller and updates the controller namespace accordingly
* Defines acceleration limits in the joint limits configuration file
* Migrates request and response adapters according to their jazzy specification
* Update description vcs branch to jazzy

Related PR: https://github.com/TrossenRobotics/trossen_arm_description/pull/20