### PR TITLE
Fix arm variant xacro arg

### DIFF
--- a/trossen_arm_bringup/launch/trossen_arm.launch.py
+++ b/trossen_arm_bringup/launch/trossen_arm.launch.py
@@ -195,7 +195,7 @@ def generate_launch_description():
                     LaunchConfiguration('robot_model'),
                     ]), '.urdf.xacro ',
                 'use_world_frame:=', LaunchConfiguration('use_world_frame'), ' ',
-                'arm_variant:=', LaunchConfiguration('arm_variant'), ' ',
+                'variant:=', LaunchConfiguration('arm_variant'), ' ',
                 'arm_side:=', LaunchConfiguration('arm_side'), ' ',
                 'ros2_control_hardware_type:=', LaunchConfiguration('ros2_control_hardware_type'), ' ',
                 'ip_address:=', LaunchConfiguration('ip_address'),

--- a/trossen_arm_moveit/launch/moveit.launch.py
+++ b/trossen_arm_moveit/launch/moveit.launch.py
@@ -61,7 +61,7 @@ def launch_setup(context, *args, **kwargs):
                 'wxai.urdf.xacro',
             ]).perform(context),
             mappings={
-                'arm_variant': LaunchConfiguration('arm_variant'),
+                'variant': LaunchConfiguration('arm_variant'),
                 'ip_address': LaunchConfiguration('ip_address'),
                 'ros2_control_hardware_type': LaunchConfiguration('ros2_control_hardware_type'),
             }


### PR DESCRIPTION
This PR fixes a bug in some launch files where [the `variant` xacro argument](https://github.com/TrossenRobotics/trossen_arm_description/blob/05a8d2f62070b613cb011948579463e1a84add0d/urdf/wxai.urdf.xacro#L4
) was not being passed properly.


Related: https://github.com/TrossenRobotics/trossen_arm_description/pull/22

cc @LucasTrac 