### PR TITLE
Make the bringup demo script executable

### DIFF
--- a/trossen_arm_bringup/CMakeLists.txt
+++ b/trossen_arm_bringup/CMakeLists.txt
@@ -11,6 +11,13 @@ install(
     share/${PROJECT_NAME}
 )
 
+install(
+  PROGRAMS
+    demos/controllers.py
+  DESTINATION
+    lib/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/trossen_arm_bringup/demos/controllers.py
+++ b/trossen_arm_bringup/demos/controllers.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2025 Trossen Robotics
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This PR installs the bringup demo script and makes it executable, allowing it to be used with

```
ros2 run trossen_arm_bringup controllers.py
```