### PR TITLE
Add gripper joint limits

### DIFF
--- a/trossen_arm_moveit/config/joint_limits.yaml
+++ b/trossen_arm_moveit/config/joint_limits.yaml
@@ -38,3 +38,8 @@ joint_limits:
     max_velocity: 9.42477796
     has_acceleration_limits: true
     max_acceleration: 3.141596
+  left_carriage_joint:
+    has_velocity_limits: true
+    max_velocity: 0.0875
+    has_acceleration_limits: true
+    max_acceleration: 0.5

--- a/trossen_arm_moveit/config/joint_limits.yaml
+++ b/trossen_arm_moveit/config/joint_limits.yaml
@@ -40,6 +40,6 @@ joint_limits:
     max_acceleration: 3.141596
   left_carriage_joint:
     has_velocity_limits: true
-    max_velocity: 0.0875
+    max_velocity: 0.25
     has_acceleration_limits: true
     max_acceleration: 0.5


### PR DESCRIPTION
Adds gripper finger joint limits to the MoveIt joint limits config file.