### PR TITLE
Fix incorrect gripper type

### DIFF
--- a/trossen_arm_moveit/config/moveit_controllers.yaml
+++ b/trossen_arm_moveit/config/moveit_controllers.yaml
@@ -25,7 +25,7 @@ moveit_simple_controller_manager:
 
   gripper_controller:
     action_ns: gripper_cmd
-    type: GripperCommand
+    type: ParallelGripperCommand
     allow_nonzero_velocity_at_trajectory_end: false
     default: true
     max_effort: 100.0


### PR DESCRIPTION
This PR fixes the gripper type used by the MoveIt controller manager, allowing the gripper client to connect to the server correctly.