### PR TITLE
Allow other arm variants to be used in hardware interface & MoveIt

### DIFF
--- a/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp
+++ b/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp
@@ -96,6 +96,9 @@ protected:
   // End effector type of the robot this hardware interface connects to
   trossen_arm::EndEffector end_effector_;
 
+  // String representation of the end effector type
+  std::string end_effector_str_;
+
   // IP address of the driver this hardware interface connects to
   std::string driver_ip_address_{DRIVER_IP_ADDRESS_DEFAULT};
 

--- a/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp
+++ b/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp
@@ -48,6 +48,10 @@ namespace trossen_arm_hardware
 
 static const char DRIVER_IP_ADDRESS_DEFAULT[] = "192.168.1.2";
 
+static const char END_EFFECTOR_BASE[] = "base";
+static const char END_EFFECTOR_FOLLOWER[] = "follower";
+static const char END_EFFECTOR_LEADER[] = "leader";
+
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 using hardware_interface::CommandInterface;
@@ -88,6 +92,9 @@ protected:
 
   // Model of the robot this hardware interface connects to
   trossen_arm::Model robot_model_;
+
+  // End effector type of the robot this hardware interface connects to
+  trossen_arm::EndEffector end_effector_;
 
   // IP address of the driver this hardware interface connects to
   std::string driver_ip_address_{DRIVER_IP_ADDRESS_DEFAULT};

--- a/trossen_arm_hardware/src/interface.cpp
+++ b/trossen_arm_hardware/src/interface.cpp
@@ -61,22 +61,22 @@ TrossenArmHardwareInterface::on_init(const hardware_interface::HardwareInfo & in
 
   // Get robot end effector
   try {
-    std::string end_effector_str = info.hardware_parameters.at("end_effector");
-    if (end_effector_str == END_EFFECTOR_BASE) {
+    end_effector_str_ = info.hardware_parameters.at("end_effector");
+    if (end_effector_str_ == END_EFFECTOR_BASE) {
       end_effector_ = trossen_arm::StandardEndEffector::wxai_v0_base;
-    } else if (end_effector_str == END_EFFECTOR_FOLLOWER) {
+    } else if (end_effector_str_ == END_EFFECTOR_FOLLOWER) {
       end_effector_ = trossen_arm::StandardEndEffector::wxai_v0_follower;
-    } else if (end_effector_str == END_EFFECTOR_LEADER) {
+    } else if (end_effector_str_ == END_EFFECTOR_LEADER) {
       end_effector_ = trossen_arm::StandardEndEffector::wxai_v0_leader;
     } else {
       RCLCPP_FATAL(
         get_logger(),
-        "Invalid 'end_effector' value specified: '%s'.", end_effector_str.c_str());
+        "Invalid 'end_effector' value specified: '%s'.", end_effector_str_.c_str());
       return CallbackReturn::FAILURE;
     }
     RCLCPP_INFO(
       get_logger(),
-      "Parameter 'end_effector' set to '%s'.", end_effector_str.c_str());
+      "Parameter 'end_effector' set to '%s'.", end_effector_str_.c_str());
   } catch (const std::out_of_range & /*e*/) {
     RCLCPP_FATAL(
       get_logger(),
@@ -245,7 +245,7 @@ TrossenArmHardwareInterface::on_configure(const rclcpp_lifecycle::State & /*prev
   try {
     arm_driver_->configure(
       robot_model_,
-      trossen_arm::StandardEndEffector::wxai_v0_base,
+      end_effector_,
       driver_ip_address_.c_str(),
       true);
   } catch (const std::exception & e) {
@@ -260,9 +260,10 @@ TrossenArmHardwareInterface::on_configure(const rclcpp_lifecycle::State & /*prev
 
   RCLCPP_INFO(
     get_logger(),
-    "TrossenArmDriver configured with model %d, IP Address '%s'.",
+    "TrossenArmDriver configured with model %d, IP Address '%s', End Effector '%s'.",
     static_cast<int>(robot_model_),
-    driver_ip_address_.c_str());
+    driver_ip_address_.c_str(),
+    end_effector_str_.c_str());
 
   return CallbackReturn::SUCCESS;
 }

--- a/trossen_arm_hardware/src/interface.cpp
+++ b/trossen_arm_hardware/src/interface.cpp
@@ -59,6 +59,31 @@ TrossenArmHardwareInterface::on_init(const hardware_interface::HardwareInfo & in
     return CallbackReturn::FAILURE;
   }
 
+  // Get robot end effector
+  try {
+    std::string end_effector_str = info.hardware_parameters.at("end_effector");
+    if (end_effector_str == END_EFFECTOR_BASE) {
+      end_effector_ = trossen_arm::StandardEndEffector::wxai_v0_base;
+    } else if (end_effector_str == END_EFFECTOR_FOLLOWER) {
+      end_effector_ = trossen_arm::StandardEndEffector::wxai_v0_follower;
+    } else if (end_effector_str == END_EFFECTOR_LEADER) {
+      end_effector_ = trossen_arm::StandardEndEffector::wxai_v0_leader;
+    } else {
+      RCLCPP_FATAL(
+        get_logger(),
+        "Invalid 'end_effector' value specified: '%s'.", end_effector_str.c_str());
+      return CallbackReturn::FAILURE;
+    }
+    RCLCPP_INFO(
+      get_logger(),
+      "Parameter 'end_effector' set to '%s'.", end_effector_str.c_str());
+  } catch (const std::out_of_range & /*e*/) {
+    RCLCPP_FATAL(
+      get_logger(),
+      "Required parameter 'end_effector' not specified.");
+    return CallbackReturn::FAILURE;
+  }
+
   // Get robot IP address
   try {
     driver_ip_address_ = info.hardware_parameters.at("ip_address");

--- a/trossen_arm_moveit/config/wxai.srdf.xacro
+++ b/trossen_arm_moveit/config/wxai.srdf.xacro
@@ -3,7 +3,11 @@
     This is a format for representing semantic information about the robot structure.
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
-<robot name="wxai">
+<robot name="wxai" xmlns:xacro="http://ros.org/wiki/xacro">
+
+    <xacro:arg name="variant" default="base"/>        <!-- 'base', 'follower' -->
+    <xacro:property name="arm_variant" value="$(arg variant)"/>
+
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
@@ -89,4 +93,10 @@
     <disable_collisions link1="link_4" link2="link_5" reason="Adjacent"/>
     <disable_collisions link1="link_4" link2="link_6" reason="Never"/>
     <disable_collisions link1="link_5" link2="link_6" reason="Adjacent"/>
+
+    <xacro:if value="${arm_variant == 'follower'}">
+        <disable_collisions link1="camera_link" link2="camera_mount_d405" reason="Adjacent"/>
+        <disable_collisions link1="camera_mount_d405" link2="link_6" reason="Adjacent"/>
+    </xacro:if>  <!-- variant == 'follower' -->
+
 </robot>

--- a/trossen_arm_moveit/launch/moveit.launch.py
+++ b/trossen_arm_moveit/launch/moveit.launch.py
@@ -67,8 +67,10 @@ def launch_setup(context, *args, **kwargs):
             }
         )
         .robot_description_semantic(
-            file_path='config/wxai.srdf',
-            mappings={},
+            file_path='config/wxai.srdf.xacro',
+            mappings={
+                'variant': LaunchConfiguration('arm_variant'),
+            },
         )
         .planning_scene_monitor(
             publish_geometry_updates=True,
@@ -198,7 +200,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'arm_variant',
             default_value='base',
-            choices=('base', 'leader'),
+            choices=('base', 'follower'),
             description='End effector variant of the Trossen Arm.',
         )
     )


### PR DESCRIPTION
This PR does the following:
* Adds end effector parsing logic to the hardware interface
* Turns the wxai srdf into a xacro
* Adds camera/camera mount disable_collisions entries in the wxai srdf
