### PR TITLE
Update trossen_arm to v1.9.0

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -6,4 +6,4 @@ repositories:
   trossen_arm:
     type: git
     url: https://github.com/TrossenRobotics/trossen_arm.git
-    version: v1.8.3
+    version: v1.9.0


### PR DESCRIPTION
This PR updates the trossen_arm dependency to v1.9.0.