### PR TITLE
Relax right carriage joint limits

### DIFF
--- a/trossen_arm_moveit/config/joint_limits.yaml
+++ b/trossen_arm_moveit/config/joint_limits.yaml
@@ -47,3 +47,10 @@ joint_limits:
     max_velocity: 0.25
     has_acceleration_limits: true
     max_acceleration: 0.5
+  right_carriage_joint:
+    min_position: -0.005  # This joint can physically go slightly below zero in closed configuration
+    max_position: 0.445  # This joint can physically go slightly above 0.44 in open configuration
+    has_velocity_limits: true
+    max_velocity: 0.25
+    has_acceleration_limits: true
+    max_acceleration: 0.5


### PR DESCRIPTION
This PR increases the allowed position limits for the right gripper finger when using MoveIt.

When sending a request like:

```bash
ros2 action send_goal /move_action moveit_msgs/action/MoveGroup '{request: {goal_constraints: [{joint_constraints: [{joint_name: left_carriage_joint, position: 0.044}]}], group_name: gripper}}'
```

Before this fix, if the right carriage joint started outside its bounds, MoveIt produced the following error:

```
[move_group-1] [INFO] [1764816126.028298802] [move_group]: Calling PlanningRequestAdapter 'CheckStartStateBounds'
[move_group-1] [ERROR] [1764816126.028344887] [move_group.moveit.moveit.ros.check_start_state_bounds]: Joint 'right_carriage_joint' from the starting state is outside bounds by: [0.0468516 ] should be in the range [0 ], [0.044 ].
[move_group-1] [ERROR] [1764816126.028413247] [move_group]: PlanningRequestAdapter 'CheckStartStateBounds' failed, because 'Start state out of bounds.'. Aborting planning pipeline.
[move_group-1] [INFO] [1764816126.028464398] [move_group.moveit.moveit.ros.move_group.move_action]: START_STATE_INVALID
```
