### PR TITLE
Fix compilation on kilted / rolling

### DIFF
--- a/trossen_arm_hardware/CMakeLists.txt
+++ b/trossen_arm_hardware/CMakeLists.txt
@@ -8,13 +8,6 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 
-set(ROS_DEPENDENCIES
-  hardware_interface
-  pluginlib
-  rclcpp
-  rclcpp_lifecycle
-)
-
 include_directories(
   include
 )
@@ -23,13 +16,12 @@ add_library(${PROJECT_NAME} SHARED
   src/interface.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${ROS_DEPENDENCIES}
-)
-
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   libtrossen_arm
-)
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle)
 
 pluginlib_export_plugin_description_file(hardware_interface ${PROJECT_NAME}.xml)
 
@@ -56,6 +48,10 @@ endif()
 
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${ROS_DEPENDENCIES})
+ament_export_dependencies(
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle)
 ament_export_dependencies(libtrossen_arm)
 ament_package()

--- a/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp
+++ b/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp
@@ -155,10 +155,7 @@ protected:
   bool gripper_effort_mode_running_{false};
 
   // Logger
-  static rclcpp::Logger get_logger()
-  {
-    return rclcpp::get_logger("trossen_arm_hardware");
-  }
+  rclcpp::Logger get_logger() const override;
 
   /**
    * @brief Check if the interface type is in the stop interfaces

--- a/trossen_arm_hardware/src/interface.cpp
+++ b/trossen_arm_hardware/src/interface.cpp
@@ -580,6 +580,11 @@ TrossenArmHardwareInterface::on_cleanup(const rclcpp_lifecycle::State & /*previo
   return CallbackReturn::SUCCESS;
 }
 
+rclcpp::Logger TrossenArmHardwareInterface::get_logger() const
+{
+  return rclcpp::get_logger("trossen_arm_hardware");
+}
+
 bool
 TrossenArmHardwareInterface::interface_type_in_stop(
   const std::vector<std::string> & stop_interfaces,


### PR DESCRIPTION
Fix following warning and error when building on rolling / kilted:

```bash
--- stderr: trossen_arm_hardware                                                                                                                                                     
CMake Deprecation Warning at /opt/ros/kilted/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:87 (message):
  ament_target_dependencies() is deprecated.  Use target_link_libraries()
  with modern CMake targets instead.  Try replacing this call with:

    target_link_libraries(trossen_arm_hardware PUBLIC
      hardware_interface::hardware_interface
      hardware_interface::mock_components
      pluginlib::pluginlib
      rclcpp::rclcpp
      rclcpp_lifecycle::rclcpp_lifecycle
    )

Call Stack (most recent call first):
  CMakeLists.txt:26 (ament_target_dependencies)
```

```bash
In file included from /craftsman_dev/src/robots/trossen_arm_ros/trossen_arm_hardware/src/interface.cpp:29:
/craftsman_dev/src/robots/trossen_arm_ros/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp:158:25: error: ‘static rclcpp::Logger trossen_arm_hardware::TrossenArmHardwareInterface::get_logger()’ cannot be declared
  158 |   static rclcpp::Logger get_logger()
      |                         ^~~~~~~~~~
In file included from /opt/ros/kilted/include/hardware_interface/hardware_interface/system_interface.hpp:18,
                 from /craftsman_dev/src/robots/trossen_arm_ros/trossen_arm_hardware/include/trossen_arm_hardware/interface.hpp:38:
/opt/ros/kilted/include/hardware_interface/hardware_interface/hardware_component_interface.hpp:574:26: error:   since ‘virtual rclcpp::Logger hardware_interface::HardwareComponentInterface::get_logger() const’ declared in base class
  574 |   virtual rclcpp::Logger get_logger() const;
      |                          ^~~~~~~~~~
gmake[2]: *** [CMakeFiles/trossen_arm_hardware.dir/build.make:76: CMakeFiles/trossen_arm_hardware.dir/src/interface.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/trossen_arm_hardware.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2

```